### PR TITLE
Additional BLUS fixes

### DIFF
--- a/permcca.m
+++ b/permcca.m
@@ -21,7 +21,7 @@ function varargout = permcca(varargin)
 %              to use Theil's residuals instead of Huh-Jhun's
 %              projection. If specified as a vector, it can be
 %              made of integer indices or logicals.
-%              The N-R selected rows of Z (S of W) must be full
+%              The R unselected rows of Z (S of W) must be full
 %              rank. Use -1 to randomly select N-R (or N-S) rows.
 % - partial  : (Optional) Boolean indicating whether
 %              this is partial (true) or part (false) CCA.

--- a/permcca.m
+++ b/permcca.m
@@ -177,7 +177,7 @@ else
             % Sel is -1 or anything else but empty [].
             foundSel = false
             while ~ foundSel
-                Sel   = randperm(N,N-R);
+                Sel   = sort(randperm(N,N-R));
                 Unsel = setdiff(1:N,Sel);
                 if rank(Z(Unsel,:)) == P
                     foundSel = true;


### PR DESCRIPTION
Hi @andersonwinkler,

Thanks for merging the main PR!

Here are two trivial changes, one of which you may not like/want.

First, the help had a typo that confused selected/unselected row count.

Second, it occurs to me that "random selection" is really about random dropping of rows, and randomly reordering the N-R remaining rows is a side effect.  It of course makes no difference, but I think we should sort the output of randperm so selection really is just about row dropping and not random permutation.